### PR TITLE
NDS-623: Many specs with HTTP ports are missing context paths

### DIFF
--- a/gui/app/catalog/addOrEdit/addOrEditSpec.html
+++ b/gui/app/catalog/addOrEdit/addOrEditSpec.html
@@ -581,7 +581,7 @@
                                                     </ng-messages>
                                                   </div>
                                                 </td>
-                                                <td><button id="addPortBtn" class="btn btn-xs btn-primary" ng-click="spec.ports.push({ protocol: portProtocol, port: portNumber, contextPath: portPath });portNumber=1;portPath='/';" 
+                                                <td><button id="addPortBtn" class="btn btn-xs btn-primary" ng-click="spec.ports.push({ protocol: portProtocol, port: portNumber, contextPath: portPath || '/' });portNumber=1;portPath='/';" 
                                                     ng-disabled="!portNumber || (portProtocol === 'http' && modifySpec['portPathField'].$invalid) || _.find(spec.ports, { protocol:portProtocol, port:portNumber })" ><i class="fa fa-fw fa-plus"></i></button></td>
                                               </tr>
                                           </table>


### PR DESCRIPTION
Default the context path to '/' for entries that are without.

See https://opensource.ncsa.illinois.edu/jira/browse/NDS-623